### PR TITLE
updated webpack-dev-server to eliminate console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
     "typescript": "~2.2.0",
-    "webpack-dev-server": "~2.3.0",
+    "webpack-dev-server": "~2.5.0",
     "autoprefixer": "^6.5.3",
     "css-loader": "^0.26.1",
     "cssnano": "^3.10.0",


### PR DESCRIPTION
Updated webpack-dev-server, fixing #4.
Error was due to webpack/webpack-dev-server#929, fixed from release 2.5.0.